### PR TITLE
Make Myself Responsible for Once

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,3 +48,4 @@ about:
 extra:
   recipe-maintainers:
     - nehaljwani
+    - leycec


### PR DESCRIPTION
By [popular demand](https://github.com/conda-forge/pydot-feedstock/pull/2#issuecomment-413569448), this pull request elevates my volunteer privileges to that of somebody responsible for something for once. Reluctantly, I think this makes me a co-maintainer of this feedstock. I can already feel the beads of sweat pooling around my armpits.

@nehaljwani, the existing feedstock maintainer, is already doing a splendid job [from somewhere in the Milky Way Galaxy](https://github.com/nehaljwani). Aside from also residing in the Milky Way Galaxy, I'm unsure what else I can offer. I'll probably just end up being the [bothersome albatross around his neck](http://www.victorianweb.org/art/illustration/wehnert/34.jpg), but hope for happier outcomes.

For safety, I'll continue to ask for peer review on significant changesets. For trivial changesets (e.g., version bumps), I'll avoid pestering others and just quietly merge the pull requests in question myself.

If that and more sounds good, sign me up for additional unwanted responsibilities! ...*sigh.*

<sup>Why do I do this to myself.</sup>